### PR TITLE
ci: use stable Go version in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version: stable
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8


### PR DESCRIPTION
- Change from go-version-file to go-version: stable for consistency