### PR TITLE
Add continue-on-failure option for extension builds

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -2,7 +2,13 @@ package rubyext
 
 import (
 	"context"
+	"errors"
 	"testing"
+)
+
+const (
+	failingExtension   = "first.ext"
+	secondaryExtension = "second.ext"
 )
 
 func TestBuilderFactory(t *testing.T) {
@@ -209,7 +215,7 @@ func TestBuildError(t *testing.T) {
 	output := []string{"line 1", "line 2", "error occurred"}
 	err := BuildError("TestBuilder", output, nil)
 
-	expected := "TestBuilder build failed: <nil>\n\nBuild output:\nline 1\nline 2\nerror occurred"
+	expected := "TestBuilder build failed\n\nBuild output:\nline 1\nline 2\nerror occurred"
 	if err.Error() != expected {
 		t.Errorf("BuildError output mismatch.\nExpected: %s\nGot: %s", expected, err.Error())
 	}
@@ -268,5 +274,169 @@ func TestBuildAllExtensions(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].Success {
 		t.Error("Expected 1 failed result for unknown extension")
+	}
+}
+
+type mockBuilder struct {
+	name       string
+	canBuildFn func(string) bool
+	buildFn    func(context.Context, *BuildConfig, string) (*BuildResult, error)
+	cleanFn    func(context.Context, *BuildConfig, string) error
+	buildCalls int
+}
+
+func (m *mockBuilder) Name() string { return m.name }
+
+func (m *mockBuilder) CanBuild(extensionFile string) bool {
+	if m.canBuildFn == nil {
+		return false
+	}
+	return m.canBuildFn(extensionFile)
+}
+
+func (m *mockBuilder) Build(ctx context.Context, config *BuildConfig, extensionFile string) (*BuildResult, error) {
+	m.buildCalls++
+	if m.buildFn == nil {
+		return &BuildResult{Success: true}, nil
+	}
+	return m.buildFn(ctx, config, extensionFile)
+}
+
+func (m *mockBuilder) Clean(ctx context.Context, config *BuildConfig, extensionFile string) error {
+	if m.cleanFn == nil {
+		return nil
+	}
+	return m.cleanFn(ctx, config, extensionFile)
+}
+
+func TestBuildAllExtensionsStopsAfterMissingBuilder(t *testing.T) {
+	factory := &BuilderFactory{}
+	trackingBuilder := &mockBuilder{
+		name: "tracking",
+		canBuildFn: func(ext string) bool {
+			return ext == "tracked.ext"
+		},
+	}
+	factory.Register(trackingBuilder)
+
+	ctx := context.Background()
+	config := &BuildConfig{GemDir: "/tmp/test", StopOnFailure: true}
+
+	results, err := factory.BuildAllExtensions(ctx, config, []string{"unknown.file", "tracked.ext"})
+
+	if err == nil {
+		t.Fatal("expected error for missing builder")
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if trackingBuilder.buildCalls != 0 {
+		t.Fatalf("expected tracking builder to be skipped, but Build was called %d times", trackingBuilder.buildCalls)
+	}
+}
+
+func TestBuildAllExtensionsHonorsContextCancellation(t *testing.T) {
+	factory := &BuilderFactory{}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cancelBuilder := &mockBuilder{
+		name: "cancel",
+		canBuildFn: func(ext string) bool {
+			return ext == failingExtension
+		},
+		buildFn: func(ctx context.Context, config *BuildConfig, extensionFile string) (*BuildResult, error) {
+			cancel()
+			return &BuildResult{Success: true}, nil
+		},
+	}
+
+	trackingBuilder := &mockBuilder{
+		name: "tracking",
+		canBuildFn: func(ext string) bool {
+			return ext == secondaryExtension
+		},
+	}
+
+	factory.Register(cancelBuilder)
+	factory.Register(trackingBuilder)
+
+	config := &BuildConfig{GemDir: "/tmp/test"}
+
+	results, err := factory.BuildAllExtensions(ctx, config, []string{failingExtension, secondaryExtension})
+
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+
+	if trackingBuilder.buildCalls != 0 {
+		t.Fatalf("expected tracking builder to be skipped, but Build was called %d times", trackingBuilder.buildCalls)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (one success, one cancellation), got %d", len(results))
+	}
+
+	if results[1].Success || !errors.Is(results[1].Error, context.Canceled) {
+		t.Fatalf("expected second result to carry context cancellation, got %+v", results[1])
+	}
+}
+
+func TestBuildAllExtensionsContinuesAfterFailure(t *testing.T) {
+	factory := &BuilderFactory{}
+
+	failureErr := errors.New("build failed")
+	failingBuilder := &mockBuilder{
+		name: "fail",
+		canBuildFn: func(ext string) bool {
+			return ext == failingExtension
+		},
+		buildFn: func(ctx context.Context, config *BuildConfig, extensionFile string) (*BuildResult, error) {
+			return &BuildResult{Success: false, Error: failureErr}, failureErr
+		},
+	}
+
+	trackingBuilder := &mockBuilder{
+		name: "tracking",
+		canBuildFn: func(ext string) bool {
+			return ext == secondaryExtension
+		},
+	}
+
+	factory.Register(failingBuilder)
+	factory.Register(trackingBuilder)
+
+	config := &BuildConfig{GemDir: "/tmp/test"}
+
+	ctx := context.Background()
+	results, err := factory.BuildAllExtensions(ctx, config, []string{failingExtension, secondaryExtension})
+
+	if err == nil {
+		t.Fatal("expected an error from failing builder")
+	}
+
+	if !errors.Is(err, failureErr) {
+		t.Fatalf("expected failureErr, got %v", err)
+	}
+
+	if trackingBuilder.buildCalls != 1 {
+		t.Fatalf("expected tracking builder to execute once, got %d", trackingBuilder.buildCalls)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected results for both extensions, got %d", len(results))
+	}
+
+	if results[0].Success {
+		t.Fatal("expected first result to be a failure")
+	}
+
+	if !results[1].Success {
+		t.Fatal("expected second result to succeed")
 	}
 }


### PR DESCRIPTION
Allow to install all extensions. 

The idea is that if you try to install sqlite3, pg and mysql with bundler without any headers. 

Bundler will fail in the first gem, you will install the headers, then it will fail in the second one. and the cycle repeat itself.

With this pattern, the next gem i s processed no matter if the previous one failed.